### PR TITLE
Remove Redux-toolkit

### DIFF
--- a/packages/frontend/components/navbar/index.tsx
+++ b/packages/frontend/components/navbar/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import { Box, Link as _Link, Button } from "@chakra-ui/core";
 import { NextComponentType } from "next";
 import Link from "next/link";
@@ -32,14 +32,14 @@ const Navbar: NextComponentType = () => {
         </Box>
         <Box display="flex" alignItems="center">
           {!isAuthenticated ? (
-            <Fragment>
+            <>
               <_Link mr={4} href="/sign-in">
                 Sign In
               </_Link>
               <Link href="/sign-up">
                 <Button variantColor="purple">Sign Up</Button>
               </Link>
-            </Fragment>
+            </>
           ) : (
             <Button variantColor="purple" onClick={handleSignOut}>
               Sign out

--- a/packages/frontend/components/pages/index/index.tsx
+++ b/packages/frontend/components/pages/index/index.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import { useQuery } from "react-apollo";
 import gql from "graphql-tag";
 import { Stack, Box } from "@chakra-ui/core";
+import { useSelector, useDispatch } from "react-redux";
+import { RootState } from "root-reducer";
+import { actions } from "slices/current-user";
 
-const fetchUsersQuery = gql`
-  query {
+const FETCH_USERS_QUERY = gql`
+  query fetchUsers {
     user {
       id
     }
@@ -12,7 +15,9 @@ const fetchUsersQuery = gql`
 `;
 
 const Index = () => {
-  const { data, loading, error } = useQuery(fetchUsersQuery);
+  const dispatch = useDispatch();
+  const { currentUser } = useSelector((state: RootState) => state);
+  const { data, loading, error } = useQuery(FETCH_USERS_QUERY);
 
   if (loading) {
     return <div>Loading...</div>;
@@ -22,12 +27,26 @@ const Index = () => {
     return <p>Error: {error.message}</p>;
   }
 
+  // const { id } = data.user[0];
+
+  // dispatch(actions.setCurrentUser({ id, name: "Harry Roberts" }));
+
   return (
-    <Stack spacing={4}>
-      {data.user.map((user: { id: number }) => {
-        return <Box key={user.id}>{user.id}</Box>;
-      })}
-    </Stack>
+    <>
+      {currentUser.user.name}
+      <button
+        onClick={() =>
+          dispatch(actions.editCurrentUser({ key: "name", value: "hello" }))
+        }
+      >
+        Click
+      </button>
+      <Stack spacing={4}>
+        {data.user.map((user: { id: number }) => {
+          return <Box key={user.id}>{user.id}</Box>;
+        })}
+      </Stack>
+    </>
   );
 };
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^10.0.27",
     "@hasura-next/components": "^1.0.0",
     "@next/bundle-analyzer": "^9.3.4",
+    "@reduxjs/toolkit": "^1.3.2",
     "apollo-boost": "^0.4.7",
     "apollo-cache": "^1.3.4",
     "apollo-client": "^2.6.8",
@@ -34,6 +35,7 @@
     "react": "^16.13.1",
     "react-apollo": "^3.1.3",
     "react-dom": "^16.13.1",
+    "react-redux": "^7.2.0",
     "subscriptions-transport-ws": "^0.9.16",
     "use-http": "^0.4.4"
   },
@@ -43,6 +45,7 @@
     "@types/node": "^13.9.8",
     "@types/react": "^16.9.31",
     "@types/react-dom": "^16.9.6",
+    "@types/react-redux": "^7.1.7",
     "babel-plugin-module-resolver": "^4.0.0",
     "cross-env": "^7.0.2",
     "husky": "^4.2.3",

--- a/packages/frontend/pages/_app.tsx
+++ b/packages/frontend/pages/_app.tsx
@@ -2,23 +2,27 @@ import React from "react";
 import NextApp from "next/app";
 import { ThemeProvider, CSSReset, Box } from "@chakra-ui/core";
 import Navbar from "components/navbar";
+import { Provider } from "react-redux";
+import store from "store";
 
 class App extends NextApp {
   render() {
     const { Component } = this.props;
 
     return (
-      <ThemeProvider>
-        <CSSReset />
-        <Box fontSize="sm">
-          <Navbar />
-          <Box bg="gray.50">
-            <Box minH="100vh" maxW="6xl" w="full" mx="auto" p={4}>
-              <Component {...this.props} />
+      <Provider store={store}>
+        <ThemeProvider>
+          <CSSReset />
+          <Box fontSize="sm">
+            <Navbar />
+            <Box bg="gray.50">
+              <Box minH="100vh" maxW="6xl" w="full" mx="auto" p={4}>
+                <Component {...this.props} />
+              </Box>
             </Box>
           </Box>
-        </Box>
-      </ThemeProvider>
+        </ThemeProvider>
+      </Provider>
     );
   }
 }

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import Head from "next/head";
 import Page from "components/pages/index";
 import WithAuthentication from "lib/with-authentication";
@@ -6,12 +6,12 @@ import withApollo from "lib/with-apollo";
 
 const IndexPage = () => {
   return (
-    <Fragment>
+    <>
       <Head>
         <title>Index Page</title>
       </Head>
       <Page />
-    </Fragment>
+    </>
   );
 };
 

--- a/packages/frontend/pages/sign-up.tsx
+++ b/packages/frontend/pages/sign-up.tsx
@@ -1,16 +1,16 @@
-import React, { Fragment } from "react";
+import React from "react";
 import Head from "next/head";
 import Page from "components/pages/sign-up";
 import WithAuthentication from "lib/with-authentication";
 
 const IndexPage = () => {
   return (
-    <Fragment>
+    <>
       <Head>
         <title>Sign Up Page</title>
       </Head>
       <Page />
-    </Fragment>
+    </>
   );
 };
 

--- a/packages/frontend/root-reducer.ts
+++ b/packages/frontend/root-reducer.ts
@@ -1,0 +1,9 @@
+import { combineReducers } from "@reduxjs/toolkit";
+import { currentUserReducer } from "slices/current-user";
+
+const rootReducer = combineReducers({
+  currentUser: currentUserReducer,
+});
+
+export type RootState = ReturnType<typeof rootReducer>;
+export default rootReducer;

--- a/packages/frontend/slices/current-user.ts
+++ b/packages/frontend/slices/current-user.ts
@@ -1,0 +1,27 @@
+import { createSlice, configureStore } from "@reduxjs/toolkit";
+
+const currentUserSlice = createSlice({
+  name: "currentUser",
+  initialState: {
+    user: {
+      id: "",
+      name: "John Doe",
+    },
+  },
+  reducers: {
+    setCurrentUser: (state, action) => {
+      state.user = action.payload;
+    },
+    editCurrentUser: (state, action) => {
+      const { key, value } = action.payload;
+
+      state.user[key] = value;
+    },
+  },
+});
+
+const actions = currentUserSlice.actions;
+const currentUserReducer = currentUserSlice.reducer;
+const store = configureStore({ reducer: currentUserSlice.reducer });
+
+export { currentUserSlice, actions, currentUserReducer, store };

--- a/packages/frontend/store.ts
+++ b/packages/frontend/store.ts
@@ -1,0 +1,10 @@
+import { configureStore } from "@reduxjs/toolkit";
+import rootReducer from "root-reducer";
+
+const store = configureStore({
+  reducer: rootReducer,
+});
+
+export type AppDispatch = typeof store.dispatch;
+
+export default store;

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -17,7 +17,10 @@
       "*": ["/*"],
       "components/*": ["components/*"],
       "lib/*": ["lib/*"],
-      "pages/*": ["pages/*"]
+      "pages/*": ["pages/*"],
+      "slices/*": ["slices/*"],
+      "root-reducer": ["root-reducer"],
+      "store": ["store"]
     }
   },
   "exclude": ["node_modules"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,53 +44,53 @@
   dependencies:
     cross-fetch "3.0.4"
 
-"@apollo/react-common@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.3.tgz#ddc34f6403f55d47c0da147fd4756dfd7c73dac5"
-  integrity sha512-Q7ZjDOeqjJf/AOGxUMdGxKF+JVClRXrYBGVq+SuVFqANRpd68MxtVV2OjCWavsFAN0eqYnRqRUrl7vtUCiJqeg==
+"@apollo/react-common@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.4.tgz#ec13c985be23ea8e799c9ea18e696eccc97be345"
+  integrity sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==
   dependencies:
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-components@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-components/-/react-components-3.1.3.tgz#8f6726847cd9b0eb4b22586b1a038d29aa8b1da4"
-  integrity sha512-H0l2JKDQMz+LkM93QK7j3ThbNXkWQCduN3s3eKxFN3Rdg7rXsrikJWvx2wQ868jmqy0VhwJbS1vYdRLdh114uQ==
+"@apollo/react-components@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@apollo/react-components/-/react-components-3.1.4.tgz#29936a4862aee1c8fe5f25549509fecd45d2f40f"
+  integrity sha512-dLZFeJ+x48nPuo2BjFjfbl8afQyazoqU8xBTidMnYy99w9DcTHtnURTw18o2dT5jkfuIJEWjbTfxyjJnHk+clw==
   dependencies:
-    "@apollo/react-common" "^3.1.3"
-    "@apollo/react-hooks" "^3.1.3"
+    "@apollo/react-common" "^3.1.4"
+    "@apollo/react-hooks" "^3.1.4"
     prop-types "^15.7.2"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-hoc@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-hoc/-/react-hoc-3.1.3.tgz#5742ee74f57611058f5ea1f966c38fc6429dda7b"
-  integrity sha512-oCPma0uBVPTcYTR5sOvtMbpaWll4xDBvYfKr6YkDorUcQVeNzFu1LK1kmQjJP64bKsaziKYji5ibFaeCnVptmA==
+"@apollo/react-hoc@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hoc/-/react-hoc-3.1.4.tgz#11accab356e15308f4721c670c7014aaeec7b3c0"
+  integrity sha512-dCzVM2/JzEWqwTocwozb9/msOgVY5EG7gh593IIXYcBfHcthSK21nIsbH/uDgwCcLSIZE2EOC3n0aKgDuoMtjA==
   dependencies:
-    "@apollo/react-common" "^3.1.3"
-    "@apollo/react-components" "^3.1.3"
+    "@apollo/react-common" "^3.1.4"
+    "@apollo/react-components" "^3.1.4"
     hoist-non-react-statics "^3.3.0"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-hooks@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-3.1.3.tgz#ad42c7af78e81fee0f30e53242640410d5bd0293"
-  integrity sha512-reIRO9xKdfi+B4gT/o/hnXuopUnm7WED/ru8VQydPw+C/KG/05Ssg1ZdxFKHa3oxwiTUIDnevtccIH35POanbA==
+"@apollo/react-hooks@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-3.1.4.tgz#2d966ed4fdf01729113850a72698faee490fd429"
+  integrity sha512-yamD5a1Gu9fGQjZYEQn2nSG+BRyde4dy055agtYOvP/5/njJBSJ25tRFbjxKf7+YW9fsu2Xguib3anoQTuesNg==
   dependencies:
-    "@apollo/react-common" "^3.1.3"
+    "@apollo/react-common" "^3.1.4"
     "@wry/equality" "^0.1.9"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
 
-"@apollo/react-ssr@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@apollo/react-ssr/-/react-ssr-3.1.3.tgz#0791280d5b735f42f87dbfe849564e78843045bc"
-  integrity sha512-fUTmEYHxSTX1GA43B8vICxXXplpcEBnDwn0IgdAc3eG0p2YK97ZrJDRFCJ5vD7fyDZsrYhMf+rAI3sd+H2SS+A==
+"@apollo/react-ssr@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@apollo/react-ssr/-/react-ssr-3.1.4.tgz#b2b4e29c480761ff749a53d19ab257037bef3648"
+  integrity sha512-c5KBD75RvSJqzpXpYngcOwLIbc7CAXhuMHrAH0J6+p4hfN+ZgqKdAOq0h143N1LfreUD4Is1PKXx4k2nPwifMw==
   dependencies:
-    "@apollo/react-common" "^3.1.3"
-    "@apollo/react-hooks" "^3.1.3"
+    "@apollo/react-common" "^3.1.4"
+    "@apollo/react-hooks" "^3.1.4"
     tslib "^1.10.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
@@ -2040,6 +2040,16 @@
   resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.1.4.tgz#0dc4ecedf523004337214187db70a46183bd945b"
   integrity sha512-QHbzXjflSlCvDd6vJwdwx16mSB+vUCCQMiU/wK/CgVNPibtpEiIbisyxkpZc55DyDFNUIqP91rSUsNae+ogGDQ==
 
+"@reduxjs/toolkit@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.3.2.tgz#cbd062f0b806eb4611afeb2b30240e5186d6dd27"
+  integrity sha512-IRI9Nx6Ys/u4NDqPvUC0+e8MH+e1VME9vn30xAmd+MBqDsClc0Dhrlv4Scw2qltRy/mrINarU6BqJp4/dcyyFg==
+  dependencies:
+    immer "^6.0.1"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -2204,6 +2214,14 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -2304,6 +2322,16 @@
   integrity sha512-S6ihtlPMDotrlCJE9ST1fRmYrQNNwfgL61UB4I1W7M6kPulUKx9fXAleW5zpdIjUQ4fTaaog8uERezjsGUj9HQ==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@^7.1.7":
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.7.tgz#12a0c529aba660696947384a059c5c6e08185c7a"
+  integrity sha512-U+WrzeFfI83+evZE2dkZ/oF/1vjIYgqrb5dGgedkqVV8HEfDFujNgWCwHL89TDuWKb47U0nTBT6PLGq4IIogWg==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react@*", "@types/react@^16.8.10", "@types/react@^16.9.26":
   version "16.9.26"
@@ -8144,6 +8172,11 @@ ignore@^4.0.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+immer@^6.0.1:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-6.0.3.tgz#94d5051cd724668160a900d66d85ec02816f29bd"
+  integrity sha512-12VvNrfSrXZdm/BJgi/KDW2soq5freVSf3I1+4CLunUM8mAGx2/0Njy0xBVzi5zewQZiwM7z1/1T+8VaI7NkmQ==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -12911,15 +12944,15 @@ react-animate-height@2.0.20:
     prop-types "^15.6.1"
 
 react-apollo@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-3.1.3.tgz#5d8540b401bba36173b63e6c5e75fa561960c63e"
-  integrity sha512-orCZNoAkgveaK5b75y7fw1MSqSHOU/Wuu9rRFOGmRQBSQVZjvV4DI+hj604rHmuN9+WDABxb5W48wTa0F/xNZQ==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-3.1.4.tgz#9a882ce557cd6e4f3c9d87b066223e9b4c5d9130"
+  integrity sha512-GDXTSava0wa9eWfPaVVhTFDZy06qbSxEW8JSJjd5l3mLIPwZoxdaI5EDjUr25h1XzsUJ/p3C64QHvsSiB9DrpQ==
   dependencies:
-    "@apollo/react-common" "^3.1.3"
-    "@apollo/react-components" "^3.1.3"
-    "@apollo/react-hoc" "^3.1.3"
-    "@apollo/react-hooks" "^3.1.3"
-    "@apollo/react-ssr" "^3.1.3"
+    "@apollo/react-common" "^3.1.4"
+    "@apollo/react-components" "^3.1.4"
+    "@apollo/react-hoc" "^3.1.4"
+    "@apollo/react-hooks" "^3.1.4"
+    "@apollo/react-ssr" "^3.1.4"
 
 react-clientside-effect@^1.2.2:
   version "1.2.2"
@@ -12989,10 +13022,21 @@ react-is@16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-redux@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
+  integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-scripts-ts@^3.1.0:
   version "3.1.0"
@@ -13245,6 +13289,19 @@ reduce-function-call@^1.0.1:
   integrity sha512-Hl/tuV2VDgWgCSEeWMLwxLZqX7OK59eU1guxXsRKTAyeYimivsKdtcV4fu3r710tpG5GmDKDhQ0HSZLExnNmyQ==
   dependencies:
     balanced-match "^1.0.0"
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux@^4.0.0:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -14603,7 +14660,7 @@ sw-toolbox@^3.4.0:
     path-to-regexp "^1.0.1"
     serviceworker-cache-polyfill "^4.0.0"
 
-symbol-observable@^1.0.2, symbol-observable@^1.0.4, symbol-observable@^1.1.0:
+symbol-observable@^1.0.2, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==


### PR DESCRIPTION
This PR removes the Redux-toolkit plugin as it isn't necessary while working with Apollo.