### PR TITLE
Add support for dynamic roles

### DIFF
--- a/backend/metadata/tables.yaml
+++ b/backend/metadata/tables.yaml
@@ -35,10 +35,28 @@
           _eq: X-Hasura-User-Id
 - table:
     schema: public
+    name: roles
+  array_relationships:
+  - name: users
+    using:
+      foreign_key_constraint_on:
+        column: role_id
+        table:
+          schema: public
+          name: users
+- table:
+    schema: public
     name: sessions
 - table:
     schema: public
+    name: user_role
+- table:
+    schema: public
     name: users
+  object_relationships:
+  - name: role
+    using:
+      foreign_key_constraint_on: role_id
   array_relationships:
   - name: feeds
     using:

--- a/backend/migrations/1610895917468_create_table_public_roles/down.sql
+++ b/backend/migrations/1610895917468_create_table_public_roles/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."roles";

--- a/backend/migrations/1610895917468_create_table_public_roles/up.sql
+++ b/backend/migrations/1610895917468_create_table_public_roles/up.sql
@@ -1,0 +1,18 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE TABLE "public"."roles"("id" uuid NOT NULL DEFAULT gen_random_uuid(), "created_at" timestamptz NOT NULL DEFAULT now(), "updated_at" timestamptz NOT NULL DEFAULT now(), "name" bpchar NOT NULL DEFAULT 'verified', PRIMARY KEY ("id") , UNIQUE ("id"));
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+RETURNS TRIGGER AS $$
+DECLARE
+  _new record;
+BEGIN
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "set_public_roles_updated_at"
+BEFORE UPDATE ON "public"."roles"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_public_roles_updated_at" ON "public"."roles" 
+IS 'trigger to set value of column "updated_at" to current timestamp on row update';

--- a/backend/migrations/1610900352309_alter_table_public_users_add_column_role/down.sql
+++ b/backend/migrations/1610900352309_alter_table_public_users_add_column_role/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."users" DROP COLUMN "role";

--- a/backend/migrations/1610900352309_alter_table_public_users_add_column_role/up.sql
+++ b/backend/migrations/1610900352309_alter_table_public_users_add_column_role/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."users" ADD COLUMN "role" uuid NULL;

--- a/backend/migrations/1610900407602_alter_table_public_users_add_column_role_id/down.sql
+++ b/backend/migrations/1610900407602_alter_table_public_users_add_column_role_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."users" DROP COLUMN "role_id";

--- a/backend/migrations/1610900407602_alter_table_public_users_add_column_role_id/up.sql
+++ b/backend/migrations/1610900407602_alter_table_public_users_add_column_role_id/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."users" ADD COLUMN "role_id" uuid NULL;

--- a/backend/migrations/1610900422725_set_fk_public_users_role_id/down.sql
+++ b/backend/migrations/1610900422725_set_fk_public_users_role_id/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" drop constraint "users_role_id_fkey";

--- a/backend/migrations/1610900422725_set_fk_public_users_role_id/up.sql
+++ b/backend/migrations/1610900422725_set_fk_public_users_role_id/up.sql
@@ -1,0 +1,5 @@
+alter table "public"."users"
+           add constraint "users_role_id_fkey"
+           foreign key ("role_id")
+           references "public"."roles"
+           ("id") on update restrict on delete restrict;

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -28,6 +28,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  bpchar: any;
   timestamptz: string;
   uuid: any;
 };
@@ -324,6 +325,19 @@ export enum Accounts_Update_Column {
   UserId = "user_id",
 }
 
+/** expression to compare columns of type bpchar. All fields are combined with logical 'AND'. */
+export type Bpchar_Comparison_Exp = {
+  _eq?: Maybe<Scalars["bpchar"]>;
+  _gt?: Maybe<Scalars["bpchar"]>;
+  _gte?: Maybe<Scalars["bpchar"]>;
+  _in?: Maybe<Array<Scalars["bpchar"]>>;
+  _is_null?: Maybe<Scalars["Boolean"]>;
+  _lt?: Maybe<Scalars["bpchar"]>;
+  _lte?: Maybe<Scalars["bpchar"]>;
+  _neq?: Maybe<Scalars["bpchar"]>;
+  _nin?: Maybe<Array<Scalars["bpchar"]>>;
+};
+
 /** columns and relationships of "feeds" */
 export type Feeds = {
   __typename?: "feeds";
@@ -522,6 +536,10 @@ export type Mutation_Root = {
   delete_feeds?: Maybe<Feeds_Mutation_Response>;
   /** delete single row from the table: "feeds" */
   delete_feeds_by_pk?: Maybe<Feeds>;
+  /** delete data from the table: "roles" */
+  delete_roles?: Maybe<Roles_Mutation_Response>;
+  /** delete single row from the table: "roles" */
+  delete_roles_by_pk?: Maybe<Roles>;
   /** delete data from the table: "sessions" */
   delete_sessions?: Maybe<Sessions_Mutation_Response>;
   /** delete single row from the table: "sessions" */
@@ -542,6 +560,10 @@ export type Mutation_Root = {
   insert_feeds?: Maybe<Feeds_Mutation_Response>;
   /** insert a single row into the table: "feeds" */
   insert_feeds_one?: Maybe<Feeds>;
+  /** insert data into the table: "roles" */
+  insert_roles?: Maybe<Roles_Mutation_Response>;
+  /** insert a single row into the table: "roles" */
+  insert_roles_one?: Maybe<Roles>;
   /** insert data into the table: "sessions" */
   insert_sessions?: Maybe<Sessions_Mutation_Response>;
   /** insert a single row into the table: "sessions" */
@@ -562,6 +584,10 @@ export type Mutation_Root = {
   update_feeds?: Maybe<Feeds_Mutation_Response>;
   /** update single row of the table: "feeds" */
   update_feeds_by_pk?: Maybe<Feeds>;
+  /** update data of the table: "roles" */
+  update_roles?: Maybe<Roles_Mutation_Response>;
+  /** update single row of the table: "roles" */
+  update_roles_by_pk?: Maybe<Roles>;
   /** update data of the table: "sessions" */
   update_sessions?: Maybe<Sessions_Mutation_Response>;
   /** update single row of the table: "sessions" */
@@ -593,6 +619,16 @@ export type Mutation_RootDelete_FeedsArgs = {
 
 /** mutation root */
 export type Mutation_RootDelete_Feeds_By_PkArgs = {
+  id: Scalars["uuid"];
+};
+
+/** mutation root */
+export type Mutation_RootDelete_RolesArgs = {
+  where: Roles_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootDelete_Roles_By_PkArgs = {
   id: Scalars["uuid"];
 };
 
@@ -648,6 +684,18 @@ export type Mutation_RootInsert_FeedsArgs = {
 export type Mutation_RootInsert_Feeds_OneArgs = {
   object: Feeds_Insert_Input;
   on_conflict?: Maybe<Feeds_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_RolesArgs = {
+  objects: Array<Roles_Insert_Input>;
+  on_conflict?: Maybe<Roles_On_Conflict>;
+};
+
+/** mutation root */
+export type Mutation_RootInsert_Roles_OneArgs = {
+  object: Roles_Insert_Input;
+  on_conflict?: Maybe<Roles_On_Conflict>;
 };
 
 /** mutation root */
@@ -708,6 +756,18 @@ export type Mutation_RootUpdate_FeedsArgs = {
 export type Mutation_RootUpdate_Feeds_By_PkArgs = {
   _set?: Maybe<Feeds_Set_Input>;
   pk_columns: Feeds_Pk_Columns_Input;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_RolesArgs = {
+  _set?: Maybe<Roles_Set_Input>;
+  where: Roles_Bool_Exp;
+};
+
+/** mutation root */
+export type Mutation_RootUpdate_Roles_By_PkArgs = {
+  _set?: Maybe<Roles_Set_Input>;
+  pk_columns: Roles_Pk_Columns_Input;
 };
 
 /** mutation root */
@@ -779,6 +839,12 @@ export type Query_Root = {
   feeds_aggregate: Feeds_Aggregate;
   /** fetch data from the table: "feeds" using primary key columns */
   feeds_by_pk?: Maybe<Feeds>;
+  /** fetch data from the table: "roles" */
+  roles: Array<Roles>;
+  /** fetch aggregated fields from the table: "roles" */
+  roles_aggregate: Roles_Aggregate;
+  /** fetch data from the table: "roles" using primary key columns */
+  roles_by_pk?: Maybe<Roles>;
   /** fetch data from the table: "sessions" */
   sessions: Array<Sessions>;
   /** fetch aggregated fields from the table: "sessions" */
@@ -842,6 +908,29 @@ export type Query_RootFeeds_AggregateArgs = {
 
 /** query root */
 export type Query_RootFeeds_By_PkArgs = {
+  id: Scalars["uuid"];
+};
+
+/** query root */
+export type Query_RootRolesArgs = {
+  distinct_on?: Maybe<Array<Roles_Select_Column>>;
+  limit?: Maybe<Scalars["Int"]>;
+  offset?: Maybe<Scalars["Int"]>;
+  order_by?: Maybe<Array<Roles_Order_By>>;
+  where?: Maybe<Roles_Bool_Exp>;
+};
+
+/** query root */
+export type Query_RootRoles_AggregateArgs = {
+  distinct_on?: Maybe<Array<Roles_Select_Column>>;
+  limit?: Maybe<Scalars["Int"]>;
+  offset?: Maybe<Scalars["Int"]>;
+  order_by?: Maybe<Array<Roles_Order_By>>;
+  where?: Maybe<Roles_Bool_Exp>;
+};
+
+/** query root */
+export type Query_RootRoles_By_PkArgs = {
   id: Scalars["uuid"];
 };
 
@@ -913,6 +1002,196 @@ export type Query_RootVerification_Requests_AggregateArgs = {
 export type Query_RootVerification_Requests_By_PkArgs = {
   id: Scalars["uuid"];
 };
+
+/** columns and relationships of "roles" */
+export type Roles = {
+  __typename?: "roles";
+  created_at: Scalars["timestamptz"];
+  id: Scalars["uuid"];
+  name: Scalars["bpchar"];
+  updated_at: Scalars["timestamptz"];
+  /** An array relationship */
+  users: Array<Users>;
+  /** An aggregated array relationship */
+  users_aggregate: Users_Aggregate;
+};
+
+/** columns and relationships of "roles" */
+export type RolesUsersArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars["Int"]>;
+  offset?: Maybe<Scalars["Int"]>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+/** columns and relationships of "roles" */
+export type RolesUsers_AggregateArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars["Int"]>;
+  offset?: Maybe<Scalars["Int"]>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+/** aggregated selection of "roles" */
+export type Roles_Aggregate = {
+  __typename?: "roles_aggregate";
+  aggregate?: Maybe<Roles_Aggregate_Fields>;
+  nodes: Array<Roles>;
+};
+
+/** aggregate fields of "roles" */
+export type Roles_Aggregate_Fields = {
+  __typename?: "roles_aggregate_fields";
+  count?: Maybe<Scalars["Int"]>;
+  max?: Maybe<Roles_Max_Fields>;
+  min?: Maybe<Roles_Min_Fields>;
+};
+
+/** aggregate fields of "roles" */
+export type Roles_Aggregate_FieldsCountArgs = {
+  columns?: Maybe<Array<Roles_Select_Column>>;
+  distinct?: Maybe<Scalars["Boolean"]>;
+};
+
+/** order by aggregate values of table "roles" */
+export type Roles_Aggregate_Order_By = {
+  count?: Maybe<Order_By>;
+  max?: Maybe<Roles_Max_Order_By>;
+  min?: Maybe<Roles_Min_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "roles" */
+export type Roles_Arr_Rel_Insert_Input = {
+  data: Array<Roles_Insert_Input>;
+  on_conflict?: Maybe<Roles_On_Conflict>;
+};
+
+/** Boolean expression to filter rows from the table "roles". All fields are combined with a logical 'AND'. */
+export type Roles_Bool_Exp = {
+  _and?: Maybe<Array<Maybe<Roles_Bool_Exp>>>;
+  _not?: Maybe<Roles_Bool_Exp>;
+  _or?: Maybe<Array<Maybe<Roles_Bool_Exp>>>;
+  created_at?: Maybe<Timestamptz_Comparison_Exp>;
+  id?: Maybe<Uuid_Comparison_Exp>;
+  name?: Maybe<Bpchar_Comparison_Exp>;
+  updated_at?: Maybe<Timestamptz_Comparison_Exp>;
+  users?: Maybe<Users_Bool_Exp>;
+};
+
+/** unique or primary key constraints on table "roles" */
+export enum Roles_Constraint {
+  /** unique or primary key constraint */
+  RolesPkey = "roles_pkey",
+}
+
+/** input type for inserting data into table "roles" */
+export type Roles_Insert_Input = {
+  created_at?: Maybe<Scalars["timestamptz"]>;
+  id?: Maybe<Scalars["uuid"]>;
+  name?: Maybe<Scalars["bpchar"]>;
+  updated_at?: Maybe<Scalars["timestamptz"]>;
+  users?: Maybe<Users_Arr_Rel_Insert_Input>;
+};
+
+/** aggregate max on columns */
+export type Roles_Max_Fields = {
+  __typename?: "roles_max_fields";
+  created_at?: Maybe<Scalars["timestamptz"]>;
+  id?: Maybe<Scalars["uuid"]>;
+  updated_at?: Maybe<Scalars["timestamptz"]>;
+};
+
+/** order by max() on columns of table "roles" */
+export type Roles_Max_Order_By = {
+  created_at?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
+  updated_at?: Maybe<Order_By>;
+};
+
+/** aggregate min on columns */
+export type Roles_Min_Fields = {
+  __typename?: "roles_min_fields";
+  created_at?: Maybe<Scalars["timestamptz"]>;
+  id?: Maybe<Scalars["uuid"]>;
+  updated_at?: Maybe<Scalars["timestamptz"]>;
+};
+
+/** order by min() on columns of table "roles" */
+export type Roles_Min_Order_By = {
+  created_at?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
+  updated_at?: Maybe<Order_By>;
+};
+
+/** response of any mutation on the table "roles" */
+export type Roles_Mutation_Response = {
+  __typename?: "roles_mutation_response";
+  /** number of affected rows by the mutation */
+  affected_rows: Scalars["Int"];
+  /** data of the affected rows by the mutation */
+  returning: Array<Roles>;
+};
+
+/** input type for inserting object relation for remote table "roles" */
+export type Roles_Obj_Rel_Insert_Input = {
+  data: Roles_Insert_Input;
+  on_conflict?: Maybe<Roles_On_Conflict>;
+};
+
+/** on conflict condition type for table "roles" */
+export type Roles_On_Conflict = {
+  constraint: Roles_Constraint;
+  update_columns: Array<Roles_Update_Column>;
+  where?: Maybe<Roles_Bool_Exp>;
+};
+
+/** ordering options when selecting data from "roles" */
+export type Roles_Order_By = {
+  created_at?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
+  name?: Maybe<Order_By>;
+  updated_at?: Maybe<Order_By>;
+  users_aggregate?: Maybe<Users_Aggregate_Order_By>;
+};
+
+/** primary key columns input for table: "roles" */
+export type Roles_Pk_Columns_Input = {
+  id: Scalars["uuid"];
+};
+
+/** select columns of table "roles" */
+export enum Roles_Select_Column {
+  /** column name */
+  CreatedAt = "created_at",
+  /** column name */
+  Id = "id",
+  /** column name */
+  Name = "name",
+  /** column name */
+  UpdatedAt = "updated_at",
+}
+
+/** input type for updating data in table "roles" */
+export type Roles_Set_Input = {
+  created_at?: Maybe<Scalars["timestamptz"]>;
+  id?: Maybe<Scalars["uuid"]>;
+  name?: Maybe<Scalars["bpchar"]>;
+  updated_at?: Maybe<Scalars["timestamptz"]>;
+};
+
+/** update columns of table "roles" */
+export enum Roles_Update_Column {
+  /** column name */
+  CreatedAt = "created_at",
+  /** column name */
+  Id = "id",
+  /** column name */
+  Name = "name",
+  /** column name */
+  UpdatedAt = "updated_at",
+}
 
 /** columns and relationships of "sessions" */
 export type Sessions = {
@@ -1246,6 +1525,12 @@ export type Subscription_Root = {
   feeds_aggregate: Feeds_Aggregate;
   /** fetch data from the table: "feeds" using primary key columns */
   feeds_by_pk?: Maybe<Feeds>;
+  /** fetch data from the table: "roles" */
+  roles: Array<Roles>;
+  /** fetch aggregated fields from the table: "roles" */
+  roles_aggregate: Roles_Aggregate;
+  /** fetch data from the table: "roles" using primary key columns */
+  roles_by_pk?: Maybe<Roles>;
   /** fetch data from the table: "sessions" */
   sessions: Array<Sessions>;
   /** fetch aggregated fields from the table: "sessions" */
@@ -1309,6 +1594,29 @@ export type Subscription_RootFeeds_AggregateArgs = {
 
 /** subscription root */
 export type Subscription_RootFeeds_By_PkArgs = {
+  id: Scalars["uuid"];
+};
+
+/** subscription root */
+export type Subscription_RootRolesArgs = {
+  distinct_on?: Maybe<Array<Roles_Select_Column>>;
+  limit?: Maybe<Scalars["Int"]>;
+  offset?: Maybe<Scalars["Int"]>;
+  order_by?: Maybe<Array<Roles_Order_By>>;
+  where?: Maybe<Roles_Bool_Exp>;
+};
+
+/** subscription root */
+export type Subscription_RootRoles_AggregateArgs = {
+  distinct_on?: Maybe<Array<Roles_Select_Column>>;
+  limit?: Maybe<Scalars["Int"]>;
+  offset?: Maybe<Scalars["Int"]>;
+  order_by?: Maybe<Array<Roles_Order_By>>;
+  where?: Maybe<Roles_Bool_Exp>;
+};
+
+/** subscription root */
+export type Subscription_RootRoles_By_PkArgs = {
   id: Scalars["uuid"];
 };
 
@@ -1407,6 +1715,9 @@ export type Users = {
   id: Scalars["uuid"];
   image?: Maybe<Scalars["String"]>;
   name?: Maybe<Scalars["String"]>;
+  /** An object relationship */
+  role?: Maybe<Roles>;
+  role_id?: Maybe<Scalars["uuid"]>;
   updated_at: Scalars["timestamptz"];
 };
 
@@ -1474,6 +1785,8 @@ export type Users_Bool_Exp = {
   id?: Maybe<Uuid_Comparison_Exp>;
   image?: Maybe<String_Comparison_Exp>;
   name?: Maybe<String_Comparison_Exp>;
+  role?: Maybe<Roles_Bool_Exp>;
+  role_id?: Maybe<Uuid_Comparison_Exp>;
   updated_at?: Maybe<Timestamptz_Comparison_Exp>;
 };
 
@@ -1492,6 +1805,8 @@ export type Users_Insert_Input = {
   id?: Maybe<Scalars["uuid"]>;
   image?: Maybe<Scalars["String"]>;
   name?: Maybe<Scalars["String"]>;
+  role?: Maybe<Roles_Obj_Rel_Insert_Input>;
+  role_id?: Maybe<Scalars["uuid"]>;
   updated_at?: Maybe<Scalars["timestamptz"]>;
 };
 
@@ -1504,6 +1819,7 @@ export type Users_Max_Fields = {
   id?: Maybe<Scalars["uuid"]>;
   image?: Maybe<Scalars["String"]>;
   name?: Maybe<Scalars["String"]>;
+  role_id?: Maybe<Scalars["uuid"]>;
   updated_at?: Maybe<Scalars["timestamptz"]>;
 };
 
@@ -1515,6 +1831,7 @@ export type Users_Max_Order_By = {
   id?: Maybe<Order_By>;
   image?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
+  role_id?: Maybe<Order_By>;
   updated_at?: Maybe<Order_By>;
 };
 
@@ -1527,6 +1844,7 @@ export type Users_Min_Fields = {
   id?: Maybe<Scalars["uuid"]>;
   image?: Maybe<Scalars["String"]>;
   name?: Maybe<Scalars["String"]>;
+  role_id?: Maybe<Scalars["uuid"]>;
   updated_at?: Maybe<Scalars["timestamptz"]>;
 };
 
@@ -1538,6 +1856,7 @@ export type Users_Min_Order_By = {
   id?: Maybe<Order_By>;
   image?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
+  role_id?: Maybe<Order_By>;
   updated_at?: Maybe<Order_By>;
 };
 
@@ -1572,6 +1891,8 @@ export type Users_Order_By = {
   id?: Maybe<Order_By>;
   image?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
+  role?: Maybe<Roles_Order_By>;
+  role_id?: Maybe<Order_By>;
   updated_at?: Maybe<Order_By>;
 };
 
@@ -1595,6 +1916,8 @@ export enum Users_Select_Column {
   /** column name */
   Name = "name",
   /** column name */
+  RoleId = "role_id",
+  /** column name */
   UpdatedAt = "updated_at",
 }
 
@@ -1606,6 +1929,7 @@ export type Users_Set_Input = {
   id?: Maybe<Scalars["uuid"]>;
   image?: Maybe<Scalars["String"]>;
   name?: Maybe<Scalars["String"]>;
+  role_id?: Maybe<Scalars["uuid"]>;
   updated_at?: Maybe<Scalars["timestamptz"]>;
 };
 
@@ -1623,6 +1947,8 @@ export enum Users_Update_Column {
   Image = "image",
   /** column name */
   Name = "name",
+  /** column name */
+  RoleId = "role_id",
   /** column name */
   UpdatedAt = "updated_at",
 }
@@ -2415,6 +2741,8 @@ export type ResolversTypes = {
   accounts_select_column: Accounts_Select_Column;
   accounts_set_input: Accounts_Set_Input;
   accounts_update_column: Accounts_Update_Column;
+  bpchar: ResolverTypeWrapper<Scalars["bpchar"]>;
+  bpchar_comparison_exp: Bpchar_Comparison_Exp;
   feeds: ResolverTypeWrapper<Feeds>;
   feeds_aggregate: ResolverTypeWrapper<Feeds_Aggregate>;
   feeds_aggregate_fields: ResolverTypeWrapper<Feeds_Aggregate_Fields>;
@@ -2438,6 +2766,26 @@ export type ResolversTypes = {
   mutation_root: ResolverTypeWrapper<{}>;
   order_by: Order_By;
   query_root: ResolverTypeWrapper<{}>;
+  roles: ResolverTypeWrapper<Roles>;
+  roles_aggregate: ResolverTypeWrapper<Roles_Aggregate>;
+  roles_aggregate_fields: ResolverTypeWrapper<Roles_Aggregate_Fields>;
+  roles_aggregate_order_by: Roles_Aggregate_Order_By;
+  roles_arr_rel_insert_input: Roles_Arr_Rel_Insert_Input;
+  roles_bool_exp: Roles_Bool_Exp;
+  roles_constraint: Roles_Constraint;
+  roles_insert_input: Roles_Insert_Input;
+  roles_max_fields: ResolverTypeWrapper<Roles_Max_Fields>;
+  roles_max_order_by: Roles_Max_Order_By;
+  roles_min_fields: ResolverTypeWrapper<Roles_Min_Fields>;
+  roles_min_order_by: Roles_Min_Order_By;
+  roles_mutation_response: ResolverTypeWrapper<Roles_Mutation_Response>;
+  roles_obj_rel_insert_input: Roles_Obj_Rel_Insert_Input;
+  roles_on_conflict: Roles_On_Conflict;
+  roles_order_by: Roles_Order_By;
+  roles_pk_columns_input: Roles_Pk_Columns_Input;
+  roles_select_column: Roles_Select_Column;
+  roles_set_input: Roles_Set_Input;
+  roles_update_column: Roles_Update_Column;
   sessions: ResolverTypeWrapper<Sessions>;
   sessions_aggregate: ResolverTypeWrapper<Sessions_Aggregate>;
   sessions_aggregate_fields: ResolverTypeWrapper<Sessions_Aggregate_Fields>;
@@ -2547,6 +2895,8 @@ export type ResolversParentTypes = {
   accounts_order_by: Accounts_Order_By;
   accounts_pk_columns_input: Accounts_Pk_Columns_Input;
   accounts_set_input: Accounts_Set_Input;
+  bpchar: Scalars["bpchar"];
+  bpchar_comparison_exp: Bpchar_Comparison_Exp;
   feeds: Feeds;
   feeds_aggregate: Feeds_Aggregate;
   feeds_aggregate_fields: Feeds_Aggregate_Fields;
@@ -2566,6 +2916,23 @@ export type ResolversParentTypes = {
   feeds_set_input: Feeds_Set_Input;
   mutation_root: {};
   query_root: {};
+  roles: Roles;
+  roles_aggregate: Roles_Aggregate;
+  roles_aggregate_fields: Roles_Aggregate_Fields;
+  roles_aggregate_order_by: Roles_Aggregate_Order_By;
+  roles_arr_rel_insert_input: Roles_Arr_Rel_Insert_Input;
+  roles_bool_exp: Roles_Bool_Exp;
+  roles_insert_input: Roles_Insert_Input;
+  roles_max_fields: Roles_Max_Fields;
+  roles_max_order_by: Roles_Max_Order_By;
+  roles_min_fields: Roles_Min_Fields;
+  roles_min_order_by: Roles_Min_Order_By;
+  roles_mutation_response: Roles_Mutation_Response;
+  roles_obj_rel_insert_input: Roles_Obj_Rel_Insert_Input;
+  roles_on_conflict: Roles_On_Conflict;
+  roles_order_by: Roles_Order_By;
+  roles_pk_columns_input: Roles_Pk_Columns_Input;
+  roles_set_input: Roles_Set_Input;
   sessions: Sessions;
   sessions_aggregate: Sessions_Aggregate;
   sessions_aggregate_fields: Sessions_Aggregate_Fields;
@@ -2833,6 +3200,11 @@ export type Accounts_Mutation_ResponseResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export interface BpcharScalarConfig
+  extends GraphQLScalarTypeConfig<ResolversTypes["bpchar"], any> {
+  name: "bpchar";
+}
+
 export type FeedsResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes["feeds"] = ResolversParentTypes["feeds"]
@@ -2959,6 +3331,18 @@ export type Mutation_RootResolvers<
     ContextType,
     RequireFields<Mutation_RootDelete_Feeds_By_PkArgs, "id">
   >;
+  delete_roles?: Resolver<
+    Maybe<ResolversTypes["roles_mutation_response"]>,
+    ParentType,
+    ContextType,
+    RequireFields<Mutation_RootDelete_RolesArgs, "where">
+  >;
+  delete_roles_by_pk?: Resolver<
+    Maybe<ResolversTypes["roles"]>,
+    ParentType,
+    ContextType,
+    RequireFields<Mutation_RootDelete_Roles_By_PkArgs, "id">
+  >;
   delete_sessions?: Resolver<
     Maybe<ResolversTypes["sessions_mutation_response"]>,
     ParentType,
@@ -3019,6 +3403,18 @@ export type Mutation_RootResolvers<
     ContextType,
     RequireFields<Mutation_RootInsert_Feeds_OneArgs, "object">
   >;
+  insert_roles?: Resolver<
+    Maybe<ResolversTypes["roles_mutation_response"]>,
+    ParentType,
+    ContextType,
+    RequireFields<Mutation_RootInsert_RolesArgs, "objects">
+  >;
+  insert_roles_one?: Resolver<
+    Maybe<ResolversTypes["roles"]>,
+    ParentType,
+    ContextType,
+    RequireFields<Mutation_RootInsert_Roles_OneArgs, "object">
+  >;
   insert_sessions?: Resolver<
     Maybe<ResolversTypes["sessions_mutation_response"]>,
     ParentType,
@@ -3078,6 +3474,18 @@ export type Mutation_RootResolvers<
     ParentType,
     ContextType,
     RequireFields<Mutation_RootUpdate_Feeds_By_PkArgs, "pk_columns">
+  >;
+  update_roles?: Resolver<
+    Maybe<ResolversTypes["roles_mutation_response"]>,
+    ParentType,
+    ContextType,
+    RequireFields<Mutation_RootUpdate_RolesArgs, "where">
+  >;
+  update_roles_by_pk?: Resolver<
+    Maybe<ResolversTypes["roles"]>,
+    ParentType,
+    ContextType,
+    RequireFields<Mutation_RootUpdate_Roles_By_PkArgs, "pk_columns">
   >;
   update_sessions?: Resolver<
     Maybe<ResolversTypes["sessions_mutation_response"]>,
@@ -3160,6 +3568,24 @@ export type Query_RootResolvers<
     ContextType,
     RequireFields<Query_RootFeeds_By_PkArgs, "id">
   >;
+  roles?: Resolver<
+    Array<ResolversTypes["roles"]>,
+    ParentType,
+    ContextType,
+    RequireFields<Query_RootRolesArgs, never>
+  >;
+  roles_aggregate?: Resolver<
+    ResolversTypes["roles_aggregate"],
+    ParentType,
+    ContextType,
+    RequireFields<Query_RootRoles_AggregateArgs, never>
+  >;
+  roles_by_pk?: Resolver<
+    Maybe<ResolversTypes["roles"]>,
+    ParentType,
+    ContextType,
+    RequireFields<Query_RootRoles_By_PkArgs, "id">
+  >;
   sessions?: Resolver<
     Array<ResolversTypes["sessions"]>,
     ParentType,
@@ -3214,6 +3640,110 @@ export type Query_RootResolvers<
     ContextType,
     RequireFields<Query_RootVerification_Requests_By_PkArgs, "id">
   >;
+};
+
+export type RolesResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["roles"] = ResolversParentTypes["roles"]
+> = {
+  created_at?: Resolver<ResolversTypes["timestamptz"], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes["uuid"], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes["bpchar"], ParentType, ContextType>;
+  updated_at?: Resolver<ResolversTypes["timestamptz"], ParentType, ContextType>;
+  users?: Resolver<
+    Array<ResolversTypes["users"]>,
+    ParentType,
+    ContextType,
+    RequireFields<RolesUsersArgs, never>
+  >;
+  users_aggregate?: Resolver<
+    ResolversTypes["users_aggregate"],
+    ParentType,
+    ContextType,
+    RequireFields<RolesUsers_AggregateArgs, never>
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Roles_AggregateResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["roles_aggregate"] = ResolversParentTypes["roles_aggregate"]
+> = {
+  aggregate?: Resolver<
+    Maybe<ResolversTypes["roles_aggregate_fields"]>,
+    ParentType,
+    ContextType
+  >;
+  nodes?: Resolver<Array<ResolversTypes["roles"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Roles_Aggregate_FieldsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["roles_aggregate_fields"] = ResolversParentTypes["roles_aggregate_fields"]
+> = {
+  count?: Resolver<
+    Maybe<ResolversTypes["Int"]>,
+    ParentType,
+    ContextType,
+    RequireFields<Roles_Aggregate_FieldsCountArgs, never>
+  >;
+  max?: Resolver<
+    Maybe<ResolversTypes["roles_max_fields"]>,
+    ParentType,
+    ContextType
+  >;
+  min?: Resolver<
+    Maybe<ResolversTypes["roles_min_fields"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Roles_Max_FieldsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["roles_max_fields"] = ResolversParentTypes["roles_max_fields"]
+> = {
+  created_at?: Resolver<
+    Maybe<ResolversTypes["timestamptz"]>,
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<Maybe<ResolversTypes["uuid"]>, ParentType, ContextType>;
+  updated_at?: Resolver<
+    Maybe<ResolversTypes["timestamptz"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Roles_Min_FieldsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["roles_min_fields"] = ResolversParentTypes["roles_min_fields"]
+> = {
+  created_at?: Resolver<
+    Maybe<ResolversTypes["timestamptz"]>,
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<Maybe<ResolversTypes["uuid"]>, ParentType, ContextType>;
+  updated_at?: Resolver<
+    Maybe<ResolversTypes["timestamptz"]>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type Roles_Mutation_ResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes["roles_mutation_response"] = ResolversParentTypes["roles_mutation_response"]
+> = {
+  affected_rows?: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  returning?: Resolver<Array<ResolversTypes["roles"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type SessionsResolvers<
@@ -3497,6 +4027,27 @@ export type Subscription_RootResolvers<
     ContextType,
     RequireFields<Subscription_RootFeeds_By_PkArgs, "id">
   >;
+  roles?: SubscriptionResolver<
+    Array<ResolversTypes["roles"]>,
+    "roles",
+    ParentType,
+    ContextType,
+    RequireFields<Subscription_RootRolesArgs, never>
+  >;
+  roles_aggregate?: SubscriptionResolver<
+    ResolversTypes["roles_aggregate"],
+    "roles_aggregate",
+    ParentType,
+    ContextType,
+    RequireFields<Subscription_RootRoles_AggregateArgs, never>
+  >;
+  roles_by_pk?: SubscriptionResolver<
+    Maybe<ResolversTypes["roles"]>,
+    "roles_by_pk",
+    ParentType,
+    ContextType,
+    RequireFields<Subscription_RootRoles_By_PkArgs, "id">
+  >;
   sessions?: SubscriptionResolver<
     Array<ResolversTypes["sessions"]>,
     "sessions",
@@ -3593,6 +4144,8 @@ export type UsersResolvers<
   id?: Resolver<ResolversTypes["uuid"], ParentType, ContextType>;
   image?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  role?: Resolver<Maybe<ResolversTypes["roles"]>, ParentType, ContextType>;
+  role_id?: Resolver<Maybe<ResolversTypes["uuid"]>, ParentType, ContextType>;
   updated_at?: Resolver<ResolversTypes["timestamptz"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -3651,6 +4204,7 @@ export type Users_Max_FieldsResolvers<
   id?: Resolver<Maybe<ResolversTypes["uuid"]>, ParentType, ContextType>;
   image?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  role_id?: Resolver<Maybe<ResolversTypes["uuid"]>, ParentType, ContextType>;
   updated_at?: Resolver<
     Maybe<ResolversTypes["timestamptz"]>,
     ParentType,
@@ -3677,6 +4231,7 @@ export type Users_Min_FieldsResolvers<
   id?: Resolver<Maybe<ResolversTypes["uuid"]>, ParentType, ContextType>;
   image?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  role_id?: Resolver<Maybe<ResolversTypes["uuid"]>, ParentType, ContextType>;
   updated_at?: Resolver<
     Maybe<ResolversTypes["timestamptz"]>,
     ParentType,
@@ -3830,6 +4385,7 @@ export type Resolvers<ContextType = any> = {
   accounts_max_fields?: Accounts_Max_FieldsResolvers<ContextType>;
   accounts_min_fields?: Accounts_Min_FieldsResolvers<ContextType>;
   accounts_mutation_response?: Accounts_Mutation_ResponseResolvers<ContextType>;
+  bpchar?: GraphQLScalarType;
   feeds?: FeedsResolvers<ContextType>;
   feeds_aggregate?: Feeds_AggregateResolvers<ContextType>;
   feeds_aggregate_fields?: Feeds_Aggregate_FieldsResolvers<ContextType>;
@@ -3838,6 +4394,12 @@ export type Resolvers<ContextType = any> = {
   feeds_mutation_response?: Feeds_Mutation_ResponseResolvers<ContextType>;
   mutation_root?: Mutation_RootResolvers<ContextType>;
   query_root?: Query_RootResolvers<ContextType>;
+  roles?: RolesResolvers<ContextType>;
+  roles_aggregate?: Roles_AggregateResolvers<ContextType>;
+  roles_aggregate_fields?: Roles_Aggregate_FieldsResolvers<ContextType>;
+  roles_max_fields?: Roles_Max_FieldsResolvers<ContextType>;
+  roles_min_fields?: Roles_Min_FieldsResolvers<ContextType>;
+  roles_mutation_response?: Roles_Mutation_ResponseResolvers<ContextType>;
   sessions?: SessionsResolvers<ContextType>;
   sessions_aggregate?: Sessions_AggregateResolvers<ContextType>;
   sessions_aggregate_fields?: Sessions_Aggregate_FieldsResolvers<ContextType>;

--- a/frontend/graphql.schema.json
+++ b/frontend/graphql.schema.json
@@ -2106,6 +2106,133 @@
         "possibleTypes": null
       },
       {
+        "kind": "SCALAR",
+        "name": "bpchar",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "bpchar_comparison_exp",
+        "description": "expression to compare columns of type bpchar. All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "bpchar",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "bpchar",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "bpchar",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "bpchar",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_is_null",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "bpchar",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "bpchar",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "bpchar",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "bpchar",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "feeds",
         "description": "columns and relationships of \"feeds\"",
@@ -3372,6 +3499,60 @@
             "deprecationReason": null
           },
           {
+            "name": "delete_roles",
+            "description": "delete data from the table: \"roles\"",
+            "args": [
+              {
+                "name": "where",
+                "description": "filter the rows which have to be deleted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "roles_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delete_roles_by_pk",
+            "description": "delete single row from the table: \"roles\"",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "uuid",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "delete_sessions",
             "description": "delete data from the table: \"sessions\"",
             "args": [
@@ -3692,6 +3873,88 @@
             "type": {
               "kind": "OBJECT",
               "name": "feeds",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_roles",
+            "description": "insert data into the table: \"roles\"",
+            "args": [
+              {
+                "name": "objects",
+                "description": "the rows to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "roles_insert_input",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "on conflict condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "roles_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_roles_one",
+            "description": "insert a single row into the table: \"roles\"",
+            "args": [
+              {
+                "name": "object",
+                "description": "the row to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "roles_insert_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "on conflict condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "roles_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4086,6 +4349,80 @@
             "type": {
               "kind": "OBJECT",
               "name": "feeds",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_roles",
+            "description": "update data of the table: \"roles\"",
+            "args": [
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "roles_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows which have to be updated",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "roles_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_roles_by_pk",
+            "description": "update single row of the table: \"roles\"",
+            "args": [
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "roles_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "pk_columns",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "roles_pk_columns_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4794,6 +5131,207 @@
             "deprecationReason": null
           },
           {
+            "name": "roles",
+            "description": "fetch data from the table: \"roles\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "roles_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "roles_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "roles_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "roles",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roles_aggregate",
+            "description": "fetch aggregated fields from the table: \"roles\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "roles_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "roles_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "roles_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "roles_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roles_by_pk",
+            "description": "fetch data from the table: \"roles\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "uuid",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sessions",
             "description": "fetch data from the table: \"sessions\"",
             "args": [
@@ -5400,6 +5938,1165 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "roles",
+        "description": "columns and relationships of \"roles\"",
+        "fields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "bpchar",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "users",
+            "description": "An array relationship",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "users_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "users_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "users_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "users",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "users_aggregate",
+            "description": "An aggregated array relationship",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "users_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "users_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "users_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "users_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "roles_aggregate",
+        "description": "aggregated selection of \"roles\"",
+        "fields": [
+          {
+            "name": "aggregate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles_aggregate_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "roles",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "roles_aggregate_fields",
+        "description": "aggregate fields of \"roles\"",
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [
+              {
+                "name": "columns",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "roles_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "distinct",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles_max_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles_min_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_aggregate_order_by",
+        "description": "order by aggregate values of table \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "roles_max_order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "roles_min_order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_arr_rel_insert_input",
+        "description": "input type for inserting array relation for remote table \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "data",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "roles_insert_input",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "on_conflict",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "roles_on_conflict",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"roles\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "roles_bool_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "roles_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "roles_bool_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "bpchar_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "users",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "users_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "roles_constraint",
+        "description": "unique or primary key constraints on table \"roles\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "roles_pkey",
+            "description": "unique or primary key constraint",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_insert_input",
+        "description": "input type for inserting data into table \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "bpchar",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "users",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "users_arr_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "roles_max_fields",
+        "description": "aggregate max on columns",
+        "fields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_max_order_by",
+        "description": "order by max() on columns of table \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "roles_min_fields",
+        "description": "aggregate min on columns",
+        "fields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_min_order_by",
+        "description": "order by min() on columns of table \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "roles_mutation_response",
+        "description": "response of any mutation on the table \"roles\"",
+        "fields": [
+          {
+            "name": "affected_rows",
+            "description": "number of affected rows by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "returning",
+            "description": "data of the affected rows by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "roles",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_obj_rel_insert_input",
+        "description": "input type for inserting object relation for remote table \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "data",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "roles_insert_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "on_conflict",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "roles_on_conflict",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_on_conflict",
+        "description": "on conflict condition type for table \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "constraint",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "roles_constraint",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "update_columns",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "roles_update_column",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "roles_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_order_by",
+        "description": "ordering options when selecting data from \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "users_aggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "users_aggregate_order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_pk_columns_input",
+        "description": "primary key columns input for table: \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "roles_select_column",
+        "description": "select columns of table \"roles\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "roles_set_input",
+        "description": "input type for updating data in table \"roles\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "bpchar",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "roles_update_column",
+        "description": "update columns of table \"roles\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -7704,6 +9401,207 @@
             "deprecationReason": null
           },
           {
+            "name": "roles",
+            "description": "fetch data from the table: \"roles\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "roles_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "roles_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "roles_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "roles",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roles_aggregate",
+            "description": "fetch aggregated fields from the table: \"roles\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "roles_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "roles_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "roles_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "roles_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roles_by_pk",
+            "description": "fetch data from the table: \"roles\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "uuid",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sessions",
             "description": "fetch data from the table: \"sessions\"",
             "args": [
@@ -8703,6 +10601,30 @@
             "deprecationReason": null
           },
           {
+            "name": "role",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "roles",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "role_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "args": [],
@@ -9046,6 +10968,26 @@
             "defaultValue": null
           },
           {
+            "name": "role",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "roles_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "role_id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -9154,6 +11096,26 @@
             "defaultValue": null
           },
           {
+            "name": "role",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "roles_obj_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "role_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -9246,6 +11208,18 @@
             "deprecationReason": null
           },
           {
+            "name": "role_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "args": [],
@@ -9321,6 +11295,16 @@
           },
           {
             "name": "name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "role_id",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -9422,6 +11406,18 @@
             "deprecationReason": null
           },
           {
+            "name": "role_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "args": [],
@@ -9497,6 +11493,16 @@
           },
           {
             "name": "name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "role_id",
             "description": null,
             "type": {
               "kind": "ENUM",
@@ -9740,6 +11746,26 @@
             "defaultValue": null
           },
           {
+            "name": "role",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "roles_order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
+            "name": "role_id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -9824,6 +11850,12 @@
             "deprecationReason": null
           },
           {
+            "name": "role_id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "updated_at",
             "description": "column name",
             "isDeprecated": false,
@@ -9899,6 +11931,16 @@
             "defaultValue": null
           },
           {
+            "name": "role_id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null
+          },
+          {
             "name": "updated_at",
             "description": null,
             "type": {
@@ -9953,6 +11995,12 @@
           },
           {
             "name": "name",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "role_id",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null


### PR DESCRIPTION
## Details
This PR adds support for dynamic roles. Currently, this boilerplate ships with two default roles:
1. admin
2. verified

The default role is **verified**. However, that can be modified in the [[...nextauth.ts]](https://github.com/ghoshnirmalya/nextjs-hasura-boilerplate/blob/master/frontend/pages/api/auth/%5B...nextauth%5D.ts) file.

Resolves https://github.com/ghoshnirmalya/nextjs-hasura-boilerplate/issues/67.