### PR TITLE
add required nodejs version in Readme doc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ It supports GraphQL Query, Mutation and Subscription out of the box.
 
 ## Requirements
 
-- [Node.js](https://nodejs.org/)
+- [Node.js - ^12.19.0 || ^14.15.0 || ^16.13.0](https://nodejs.org/)
 - [npm](https://www.npmjs.com/)
 - [Docker](https://www.docker.com/)
 


### PR DESCRIPTION
When I starting use with nodejs 18 I receive message:

```bash
error next-auth@4.12.2: The engine "node" is incompatible with this module. Expected version "^12.19.0 || ^14.15.0 || ^16.13.0". Got "18.17.0"
```

To user not receive this erro, I add in Readme of project the version required